### PR TITLE
Add gem better errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,8 @@ gem 'rb-readline'
 group :development, :test do
   gem 'pry-rails'
   gem 'pry-doc'
+  gem 'better_errors'
+  gem 'binding_of_caller'
 end
 
 gem 'active_hash'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,6 +30,12 @@ GEM
       thread_safe (~> 0.1)
       tzinfo (~> 1.1)
     arel (5.0.1.20140414130214)
+    better_errors (2.1.1)
+      coderay (>= 1.0.0)
+      erubis (>= 2.6.6)
+      rack (>= 0.9.0)
+    binding_of_caller (0.7.2)
+      debug_inspector (>= 0.0.1)
     builder (3.2.2)
     coderay (1.1.0)
     coffee-rails (4.0.1)
@@ -40,6 +46,7 @@ GEM
       execjs
     coffee-script-source (1.10.0)
     commonjs (0.2.7)
+    debug_inspector (0.0.2)
     erb2haml (0.1.5)
       html2haml
     erubis (2.7.0)
@@ -174,6 +181,8 @@ PLATFORMS
 
 DEPENDENCIES
   active_hash
+  better_errors
+  binding_of_caller
   coffee-rails (~> 4.0.0)
   erb2haml
   haml-rails

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -35,5 +35,7 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 
-  BetterErrors::Middleware.allow_ip! "192.168.55.1"
+# 例えばVagrantなどの仮想マシン上で開発する場合、ホスト側からブラウザでアクセスしても
+# better_errorsの画面が描画されないため、そのような場合は下記のように許可IPを指定する
+#  BetterErrors::Middleware.allow_ip! "192.168.55.1"
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -34,4 +34,6 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  BetterErrors::Middleware.allow_ip! "192.168.55.1"
 end


### PR DESCRIPTION
[pull request training]
develop環境とtest環境向けに、better_errorsとbinding_of_callerを追加し、デバッグを快適に実施できるように拡張。
また、vagrant上で開発することを想定して、192.168.55.1(vagrantで開発する際の、host側のip)からのアクセスにおいて、better_errorsを利用させるように設定を変更。
