### PR TITLE
add link to terminal_historys from terminal.show

### DIFF
--- a/app/views/terminals/show.html.haml
+++ b/app/views/terminals/show.html.haml
@@ -36,3 +36,4 @@
   :method => 'delete',                                                                                         |
   :data => { :confirm => t('.confirm', :default => t("helpers.links.confirm", :default => 'Are you sure?')) }, |
   :class => 'btn btn-danger'
+= link_to 'history', terminal_historys_path(@terminal)


### PR DESCRIPTION
端末をshowしたページに、操作履歴のページに飛べるように修正。
