### PR TITLE
triming needlessness '|'

### DIFF
--- a/app/views/application_types/index.html.haml
+++ b/app/views/application_types/index.html.haml
@@ -17,13 +17,15 @@
         %td= application_type.remark
         %td= l application_type.created_at
         %td
-          = link_to t('.edit', :default => t("helpers.links.edit")),                         |
+          = link_to t('.edit', :default => t("helpers.links.edit")),
             edit_application_type_path(application_type), :class => 'btn btn-default btn-xs'
-          = link_to t('.destroy', :default => t("helpers.links.destroy")),                                               |
-            application_type_path(application_type),                                                                     |
-            :method => :delete,                                                                                          |
-            :data => { :confirm => t('.confirm', :default => t("helpers.links.confirm", :default => 'Are you sure?')) }, |
+
+          = link_to t('.destroy', :default => t("helpers.links.destroy")),
+            application_type_path(application_type),
+            :method => :delete,
+            :data => { :confirm => t('.confirm', :default => t("helpers.links.confirm", :default => 'Are you sure?')) },
             :class => 'btn btn-xs btn-danger'
-= link_to t('.new', :default => t("helpers.links.new")), |
-  new_application_type_path,                             |
-  :class => 'btn btn-primary'                            |
+
+= link_to t('.new', :default => t("helpers.links.new")),
+  new_application_type_path,
+  :class => 'btn btn-primary'

--- a/app/views/applications/index.html.haml
+++ b/app/views/applications/index.html.haml
@@ -19,11 +19,12 @@
         %td= application.remark
         %td= l application.created_at
         %td
-          = link_to t('.destroy', :default => t("helpers.links.destroy")),                                               |
-            application_path(application),                                                                               |
-            :method => :delete,                                                                                          |
-            :data => { :confirm => t('.confirm', :default => t("helpers.links.confirm", :default => 'Are you sure?')) }, |
+          = link_to t('.destroy', :default => t("helpers.links.destroy")),
+            application_path(application),
+            :method => :delete,
+            :data => { :confirm => t('.confirm', :default => t("helpers.links.confirm", :default => 'Are you sure?')) },
             :class => 'btn btn-xs btn-danger'
-= link_to t('.new', :default => t("helpers.links.new")), |
-  new_application_path,                                  |
+
+= link_to t('.new', :default => t("helpers.links.new")),
+  new_application_path,
   :class => 'btn btn-primary'

--- a/app/views/sims/index.html.haml
+++ b/app/views/sims/index.html.haml
@@ -23,14 +23,17 @@
         %td= sim.remark
         %td= l sim.created_at
         %td
-          = link_to t('.edit', :default => t("helpers.links.edit")), |
+          = link_to t('.edit', :default => t("helpers.links.edit")),
             edit_sim_path(sim), :class => 'btn btn-default btn-xs'
-          = link_to t('.destroy', :default => t("helpers.links.destroy")),                                               |
-            sim_path(sim),                                                                                               |
-            :method => :delete,                                                                                          |
-            :data => { :confirm => t('.confirm', :default => t("helpers.links.confirm", :default => 'Are you sure?')) }, |
+
+          = link_to t('.destroy', :default => t("helpers.links.destroy")),
+            sim_path(sim),
+            :method => :delete,
+            :data => { :confirm => t('.confirm', :default => t("helpers.links.confirm", :default => 'Are you sure?')) },
             :class => 'btn btn-xs btn-danger'
+
           = link_to 'history', sim_historys_path(sim), :class => 'btn btn-default btn-xs'
-= link_to t('.new', :default => t("helpers.links.new")), |
-  new_sim_path,                                          |
-  :class => 'btn btn-primary'                            |
+
+= link_to t('.new', :default => t("helpers.links.new")),
+  new_sim_path,
+  :class => 'btn btn-primary'

--- a/app/views/terminals/index.html.haml
+++ b/app/views/terminals/index.html.haml
@@ -25,14 +25,19 @@
         %td= terminal.remark
         %td= l terminal.updated_at
         %td
-          = link_to t('.edit', :default => t("helpers.links.edit")),         |
-            edit_terminal_path(terminal), :class => 'btn btn-default btn-xs'
-          = link_to t('.destroy', :default => t("helpers.links.destroy")),                                               |
-            terminal_path(terminal),                                                                                     |
-            :method => :delete,                                                                                          |
-            :data => { :confirm => t('.confirm', :default => t("helpers.links.confirm", :default => 'Are you sure?')) }, |
+          = link_to t('.edit', :default => t("helpers.links.edit")),
+            edit_terminal_path(terminal),
+            :class => 'btn btn-default btn-xs'
+
+          = link_to t('.destroy', :default => t("helpers.links.destroy")),
+            terminal_path(terminal),
+            :method => :delete,
+            :data => { :confirm => t('.confirm', :default => t("helpers.links.confirm", :default => 'Are you sure?')) },
             :class => 'btn btn-xs btn-danger'
-          = link_to 'history', terminal_historys_path(terminal), :class => 'btn btn-default btn-xs'
-= link_to t('.new', :default => t("helpers.links.new")), |
-  new_terminal_path,                                     |
+
+          = link_to 'history', terminal_historys_path(terminal),
+            :class => 'btn btn-default btn-xs'
+
+= link_to t('.new', :default => t("helpers.links.new")),
+  new_terminal_path,
   :class => 'btn btn-primary'


### PR DESCRIPTION
index.html.hamlのactionへのリンクに記述されていた"|"は、削除しても動くようなので、削除してindent・改行を修正しました。
